### PR TITLE
Fix git authentication [DELIVERY-7293]

### DIFF
--- a/alt-src
+++ b/alt-src
@@ -144,6 +144,7 @@ class BaseProcessor(object):
         self.logger = logging.getLogger("altsrc")
         self.error_log = None
         self.checkout = None
+        self.git_auth_set = False
 
         self.mmd = None
         self.mmd_parsed = None
@@ -397,11 +398,14 @@ class BaseProcessor(object):
         return git_url
 
     def git_base_cmd(self):
-        cmd = ['git',
-                '-c', 'user.name=%s' % self.options.config['git_name'],
-                '-c', 'user.email=%s' % self.options.config['git_email'],
-        ]
-        return cmd
+        if not self.git_auth_set:
+            name, email = self.options.config['git_name'], self.options.config['git_email']
+            os.environ['GIT_AUTHOR_NAME'] = name
+            os.environ['GIT_COMMITTER_NAME'] = name
+            os.environ['GIT_AUTHOR_EMAIL'] = email
+            os.environ['GIT_COMMITTER_EMAIL'] = email
+            self.git_auth_set = True
+        return ['git', ]
 
     def get_workdir(self):
         if not os.path.isdir(self.options.config['stagedir']):


### PR DESCRIPTION
Previously, git commands executed by alt-src used the -c option to
provide git name and email but this option is not supported by the
version of git on pub workers. This change sets the git environment
variables for authentication and removes the -c option from git
commands.