### PR TITLE
Direct pytest-cov to alt_src package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ whitelist_externals = sh
 
 [testenv:cov]
 basepython = python2.7
-commands = pytest --cov-report=html --cov=. {posargs}
+commands = pytest --cov-report=html --cov=alt_src {posargs}
 
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*
@@ -26,7 +26,7 @@ deps =
 	coveralls
 usedevelop = true
 commands =
-	pytest --cov=. {posargs}
+	pytest --cov=alt_src {posargs}
 	coveralls
 
 [pytest]


### PR DESCRIPTION
This commit directs pytest-cov to generate coverage reports for only the alt_src package rather than all python files in the repo (although they were filtered by .coveragerc).