### PR TITLE
Improve integration with PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Alt-src
 
 Alt-src is a tool for pushing SRPM metadata into a git repo.
 
+[![PyPI version](https://badge.fury.io/py/alt-src.svg)](https://badge.fury.io/py/alt-src)
 [![Build Status](https://travis-ci.org/release-engineering/alt-src.svg?branch=master)](https://travis-ci.org/release-engineering/alt-src)
 [![Coverage Status](https://coveralls.io/repos/github/release-engineering/alt-src/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/alt-src?branch=master)
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,15 @@ def get_requirements():
         return f.read().splitlines()
 
 
+def get_long_description():
+    with open("README.md") as f:
+        text = f.read()
+
+    # Long description is everything after README's initial heading
+    idx = text.find("\n\n")
+    return text[idx:]
+
+
 setup(
       name="alt-src",
       version="1.0.0",
@@ -19,6 +28,8 @@ setup(
       url="https://github.com/release-engineering/alt-src",
       license="GNU General Public License",
       description=get_description(),
+      long_description=get_long_description(),
+      long_description_content_type="text/markdown",
       classifiers=[
             "Programming Language :: Python :: 2",
             "Programming Language :: Python :: 2.4",


### PR DESCRIPTION
- Make sure there is a long description in the uploads to PyPI.
  Without this, the PyPI page appears blank.
  As also done for our other projects, reuse the README.md for this.

- Add a README badge for PyPI to advertise the project's presence
  and last released version.