### PR TITLE
Use BaseLoader when loading yaml to avoid conversion errors

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -314,7 +314,7 @@ class BaseProcessor(object):
             self.read_srpm()
 
     def read_mmd(self):
-        self.mmd_parsed = yaml.load(self.mmd)
+        self.mmd_parsed = yaml.load(self.mmd, Loader=yaml.BaseLoader)
         module_data = self.mmd_parsed['data']
         fobj = open(self.source_file)
         try:

--- a/tests/data/module_source/modulemd.src.txt
+++ b/tests/data/module_source/modulemd.src.txt
@@ -1,6 +1,7 @@
 document: modulemd
 version: 2
 data:
+  stream: 1.10
   summary: PostgreSQL server and client module
   description: PostgreSQL is an advanced Object-Relational database management
                system (DBMS). The postgresql-server package contains the

--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -150,8 +150,8 @@ def remove_handlers():
 
 def get_test_mmd_str_and_dict():
     name = "my_package"
-    stream = "42"
-    version = 1
+    stream = "42.2"
+    version = "1.10"
     context = "c_1"
     summary = "foo_summary"
     mmd_dict = {'data':
@@ -162,7 +162,17 @@ def get_test_mmd_str_and_dict():
                      'summary': summary
                     }
                }
-    mmd_str = yaml.dump(mmd_dict)
+    mmd_str = """
+---
+document: modulemd
+version: 2
+data:
+  name: my_package
+  stream: 42.2
+  summary: foo_summary
+  context: c_1
+  version: 1.10
+"""
 
     return mmd_str, mmd_dict['data']
 


### PR DESCRIPTION
In order to avoid error in conversions like "1.10" => 1.0
BaseLoader is needed to be passed as argument when loading yaml
files