### PR TITLE
Remove local tag if already exists [DELIVERY-7359]

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -631,6 +631,17 @@ Staging failed for %(nvr)s.
             return True
         return False
 
+    def list_local_tags(self):
+        cmd = self.git_base_cmd()
+        cmd.extend(['tag', '-l'])
+        out, _ = self.get_output(cmd, cwd=self.checkout)
+        return out.split()
+
+    def delete_local_tag(self, tag):
+        cmd = self.git_base_cmd()
+        cmd.extend(['tag', '-d', tag])
+        self.log_cmd(cmd, cwd=self.checkout)
+
 
 class Stager(BaseProcessor):
     MMD_DEBRAND_RTYPES = [
@@ -1823,6 +1834,10 @@ class Pusher(BaseProcessor):
         #tag
         if self.options.config['push_tags']:
             tagname = self.get_import_tagname()
+            if tagname in self.list_local_tags():
+                self.logger.info("Deleting local tag %s", tagname)
+                self.delete_local_tag(tagname)
+
             cmd = self.git_base_cmd()
             cmd.extend(['tag', '-a', '-m', 'import %s' % self.nvr, tagname])
             self.log_cmd(cmd, cwd=self.checkout)

--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -18,7 +18,7 @@ from .matchers import exits
 # ensure python2 before attempting to import sources
 if sys.version_info < (3, 0):
     from alt_src.alt_src import (main, BaseProcessor, acquire_lock, StartupError,
-                         SanityError, InputError, CONFIG_DEFAULTS, Stager,
+                         SanityError, InputError, CONFIG_DEFAULTS, Stager, Pusher,
                          CommandError)
 
 xfail = pytest.mark.xfail(sys.version_info >= (3, 0), reason="Incompatible with python3")
@@ -378,6 +378,64 @@ def test_repush_without_tag(config_file, pushdir, lookasidedir, branch,
     w_expect = '[WARNING] Already pushed'
     dupwarn = [l for l in out_lines if w_expect in l]
     assert dupwarn
+
+
+@xfail(strict=True)
+@pytest.mark.parametrize('branch,name,version,release', [
+    ('c7', 'grub2', '2.02', '0.64.el7'),
+])
+def test_push_with_existing_local_tag(config_file, pushdir, lookasidedir,
+                                      branch, name, version, release, default_config, capsys):
+    """Push with already existing tag locally"""
+
+    nvr = '-'.join([name, version, release])
+    tag_name = "imports/%s/%s" % (branch, nvr)
+    workdir = default_config['stagedir']+'/c7/rpms/g/grub2/grub2-2.02-0.64.el7/checkout'
+    os.makedirs(workdir)
+
+    # init repo
+    cmd = ['git', 'init']
+    check_call(cmd, cwd=workdir)
+    # create file for testing commit
+    file_to_stage = os.path.join(workdir, "fake.file")
+    open(file_to_stage, 'w')
+    # stage file
+    cmd = ['git', 'add', "fake.file"]
+    check_call(cmd, cwd=workdir)
+    # create fake commit, so we can tag it
+    cmd = ['git', 'commit', '-m', 'tagging test']
+    check_call(cmd, cwd=workdir)
+    # create local tag - this will simulate already existing tag that needs to be deleted
+    cmd = ['git', 'tag', tag_name]
+    check_call(cmd, cwd=workdir)
+
+    mock_options = MagicMock(koji=False, branch='c7',
+                             git_push_url=os.path.join(pushdir, '%(package)s.git'),
+                             log_level='DEBUG')
+
+    # setup logger for capturing stdout/stderr
+    logger = logging.getLogger("altsrc")
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler)
+
+    with patch('os.path.isfile', return_value=True):
+        with patch('alt_src.alt_src.Pusher.git_push_url', return_value=workdir):
+            pusher = Pusher(mock_options)
+            # do a bit more setup for test
+            pusher.nvr = nvr
+            pusher.checkout = workdir
+            pusher.git_auth_set = True
+            # run desired function, that will delete already existing tag from previous push
+            pusher.push_git('PUSHED')
+
+    out, err = capsys.readouterr()
+    out_lines = out.splitlines()
+
+    assert "Deleting local tag %s" % tag_name in out_lines
+    assert "" in err
+    # remove created logger handler so they don't interfere with other tests
+    remove_handlers()
 
 
 @xfail(strict=True)

--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -433,7 +433,7 @@ def test_push_with_existing_local_tag(config_file, pushdir, lookasidedir,
     out_lines = out.splitlines()
 
     assert "Deleting local tag %s" % tag_name in out_lines
-    assert "" in err
+    assert not err
     # remove created logger handler so they don't interfere with other tests
     remove_handlers()
 

--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -413,6 +413,8 @@ def test_push_with_existing_local_tag(config_file, pushdir, lookasidedir,
                              git_push_url=os.path.join(pushdir, '%(package)s.git'),
                              log_level='DEBUG')
 
+    # clean handlers so they don't interfere with this test
+    remove_handlers()
     # setup logger for capturing stdout/stderr
     logger = logging.getLogger("altsrc")
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
This commit adds support for scenario when one alt-src push
failed to finish but there was already local git tag created.

When re-push of the same push is triggered, it lists current
local tags and if there is a local tag present with the same name
that  is going to be created, delete the old one and create a new one.