### PR TITLE
Fix new branch initialization when target repo has no default branch

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -851,16 +851,22 @@ If you find this file in a distro specific branch, it means that no content has 
                 self.logger.warn('Base branch %s missing, staging on an orphan branch', self.options.branch)
                 # create new branch
                 cmd = ['git', 'checkout', '-b', branchname]
-                self.log_cmd(cmd, cwd=dst)
+                retval = self.log_cmd(cmd, cwd=dst, fatal=False)
+                if retval:
+                    # commit for branch initialization
+                    # on error when switching with empty HEAD/unborn branch
+                    cmd = ['git', 'commit', '--allow-empty', '-m', 'init_branch']
+                    self.log_cmd(cmd, cwd=dst)
+                    # switch to new branch
+                    cmd = ['git', 'checkout', '-b', branchname]
+                    self.log_cmd(cmd, cwd=dst)
                 # orphan the branch (remove parent)
                 cmd = ['git', 'update-ref', '-d', 'refs/heads/%s' % branchname]
                 self.log_cmd(cmd, cwd=dst)
                 # remove staged files
                 cmd = ['git', 'rm', '-rf', '--ignore-unmatch', '.']
                 self.log_cmd(cmd, cwd=dst)
-                # commit branch initialization
-                cmd = ['git', 'commit', '--allow-empty', '-m', 'init_branch']
-                self.log_cmd(cmd, cwd=dst)
+
             else:
                 cmd = ['git', 'checkout', '-b', branchname, base]
                 self.log_cmd(cmd, cwd=dst)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-koji < 1.20
+koji
 rpm
 requests
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-koji
+koji < 1.20
 rpm
 requests
 PyYAML

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,10 @@ PyHamcrest
 configparser
 six > 1.10
 
+# koji 1.20 doesn't include it
+# as dependency
+rpm-py-installer
+
 # Locked for python 2.7 support
 pytest-cov==2.5.1
 pytest==3.9.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 mock
 PyHamcrest
-koji
 configparser
 six > 1.10
 

--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -749,7 +749,7 @@ def test_stage_repo_no_master(config_file, pushdir, capsys, default_config):
     def log_cmd(cmd, fatal=True, **kwargs):
         # fail creating orphan branch first time
         # other calls respond as executed
-        err_cmd = ['git', 'checkout', '--orphan', 'altsrc-stage-c7']
+        err_cmd = ['git', 'checkout', '-b', 'altsrc-stage-c7']
 
         if err_cmd == cmd and err_cmd_call_cnt[0] == 1:
             err_cmd_call_cnt[0] += 1


### PR DESCRIPTION
Some target repos have no default branch. Thus an empty HEAD
that causes an error while initializing/switching to a new
branch. This patch fixes the issue by creating an empty
commit to create/init a branch and then switch to the
required branch

Fix #17