### PR TITLE
Use rpm-py-installer instead of rpm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 koji
-rpm
+rpm-py-installer
 requests
 PyYAML
 simplejson


### PR DESCRIPTION
'rpm' doesn't have package available in pypi therefore
we must use 'rpm-py-installer' instead.