### PR TITLE
Update setup.py to include Changelog path for PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - n/a
 
-## 1.1.0 - 2020-04-02
+## [1.1.0] - 2020-04-02
 
 ### Changed
 - Used Yaml BaseLoader to avoid conversion errors

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,14 @@ setup(
       long_description=get_long_description(),
       long_description_content_type="text/markdown",
       classifiers=[
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Developers",
             "Programming Language :: Python :: 2",
             "Programming Language :: Python :: 2.4",
             "Programming Language :: Python :: 2.6",
             "Programming Language :: Python :: 2.7",
             "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+            "Topic :: Software Development :: Libraries :: Python Modules",
       ],
       install_requires=get_requirements(),
       entry_points={
@@ -43,4 +46,7 @@ setup(
                   "alt-src = alt_src:entry_point",
             ],
       },
+      project_urls={
+        "Changelog": "https://github.com/release-engineering/alt-src/blob/master/CHANGELOG.md",
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
             "Programming Language :: Python :: 2.6",
             "Programming Language :: Python :: 2.7",
             "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-            "Topic :: Software Development :: Libraries :: Python Modules",
       ],
       install_requires=get_requirements(),
       entry_points={


### PR DESCRIPTION
PyPI uses the Changelog path in setup.py to show the Changelog
on the portal. So added the path in setup.py along with other
relevant information about the package. Also, modified the
Changelog.md to hyperlink the list of commits in a specific
version.