### PR TITLE
tests: fix a function wrongly marked as fixture

### DIFF
--- a/tests/test_rpms.py
+++ b/tests/test_rpms.py
@@ -38,9 +38,8 @@ def tempdir():
     shutil.rmtree(path)
 
 
-@pytest.fixture
 def rulesdir():
-    """Yields path to rules directory used within tests.
+    """Returns path to rules directory used within tests.
 
     Uses tests/data/rules by default, but ALTSRC_TEST_RULESDIR can be
     set to test against a different path."""


### PR DESCRIPTION
This was marked as pytest.fixture, but it was never used as such,
it was simply called as a regular function.
This was deprecated, and on recent versions of pytest gives a
fatal error, see:
https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly

As this doesn't depend on any other fixtures or have any teardown
logic after the test completes, it doesn't need to be a fixture,
so just make it a regular function.