### PR TITLE
Fix compatibility with old version of six

### DIFF
--- a/legacy.constraints
+++ b/legacy.constraints
@@ -1,0 +1,3 @@
+# Add oldest supported version of selected dependencies here
+# to ensure they're tested on at least one CI config
+six==1.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,6 @@ envlist = py27, py36
 
 [testenv]
 deps =
-	# Note: we need to explicitly list requirements.txt here
-	# so it's processed at the same time as the constraints file
 	-rrequirements.txt
 	-rtest-requirements.txt
 commands = pytest {posargs}
@@ -20,6 +18,7 @@ basepython = python2.7
 deps =
 	-rrequirements.txt
 	-rtest-requirements.txt
+	-clegacy.constraints
 	coveralls
 usedevelop = true
 commands =


### PR DESCRIPTION
six.ensure_text was introduced in six 1.12.0, but six 1.9.0 seems
to be the latest version of the package shipped for RHEL6, so
make sure it's compatible with that. We introduce our own tiny
helper to replace ensure_text.

The CI was also updated to ensure that at least one configuration
tests against the appropriate version of six.