### PR TITLE
CI: use specific version of rpm-python in legacy tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,9 @@ commands = pytest --cov-report=html --cov=alt_src {posargs}
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*
 basepython = python2.7
+setenv =
+    # Use older version of rpm-python to ensure backwards-compatibility
+    RPM_PY_VERSION = 4.10.0
 deps =
 	-rrequirements.txt
 	-rtest-requirements.txt


### PR DESCRIPTION
In the test configuration where we're trying to test the oldest
supported version of modules, let's request rpm-py-installer to
install an older version of rpm-python. This helps ensure
compatibility on older systems as far back as RHEL6.

(It'd be best if we could use version 4.8.0 for this, being the
version on RHEL6, but 4.10.0 seems to be the oldest where
installation via rpm-py-installer is able to succeed.)