### PR TITLE
Use six version 1.8.0 for shlex_quote from six.moves

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ rpm-py-installer
 requests
 PyYAML
 simplejson
-six
+six>=1.8.0


### PR DESCRIPTION
shlex_quote from six.moves used in alt_src.py was introduced
in version 1.8.0. So adding a constraint to use this version
or higher.