### PR TITLE
Make sure the SOURCES dir. exists for listdir().

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -950,9 +950,9 @@ If you find this file in a distro specific branch, it means that no content has 
             if fname != '.git':
                 raise SanityError('Failed to clear checkout')
         sourcedir = os.path.join(dst, 'SOURCES/')
+        os.makedirs(sourcedir) # RPM sources can be empty.
         if self.mmd:
             # move module src to stage dir
-            os.makedirs(sourcedir)
             shutil.copy(self.source_file, os.path.join(sourcedir))
         else:
             # explode our srpm


### PR DESCRIPTION
There are packages like go-toolset and llvm-toolset that contain no SOURCE files and thus. don't create a SOURCES dir. then the listdir() on line 964 tracebacks. The other workaround is to os.path.exists() or test for the OSError (no such file/dir). This seemed easier though, and future proofs against similar assumptions.