### PR TITLE
Fix the bug "Crash when a config file is missing"

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -2115,7 +2115,7 @@ def wipe_git_dir(dirname):
 
 
 def die(msg):
-    self.logger.error(msg)
+    logging.getLogger("altsrc").error(msg)
     sys.exit(1)
 
 


### PR DESCRIPTION
This bug is resulted from the wrong usage of logger configuration.
```
(alt-src) [dichen@freedom alt-src]$ alt-src --push c7 dummy-basesystem-10.0-6.src.rpm -c xxxxxxx
Traceback (most recent call last):
  File "/home/dichen/.local/share/virtualenvs/alt-src-2aYAcnS_/bin/alt-src", line 8, in <module>
    sys.exit(entry_point())
  File "/home/dichen/.local/share/virtualenvs/alt-src-2aYAcnS_/lib/python3.6/site-packages/alt_src/alt_src.py", line 2228, in entry_point
    main(sys.argv[1:])
  File "/home/dichen/.local/share/virtualenvs/alt-src-2aYAcnS_/lib/python3.6/site-packages/alt_src/alt_src.py", line 2202, in main
    options.config = get_config(options.cfile, options.copts)
  File "/home/dichen/.local/share/virtualenvs/alt-src-2aYAcnS_/lib/python3.6/site-packages/alt_src/alt_src.py", line 93, in get_config
    die("Missing config file: %s" % cfile)
  File "/home/dichen/.local/share/virtualenvs/alt-src-2aYAcnS_/lib/python3.6/site-packages/alt_src/alt_src.py", line 2118, in die
    self.logger.error(msg)
NameError: name 'self' is not defined
```
I am using Python 3.6.10 on Fedora 31