### PR TITLE
fix wrong logging behavior [RHELDST-3788]

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -2120,8 +2120,7 @@ def die(msg):
 
 
 def setup_logging(options):
-    logger = logging.getLogger("altsrc")
-    logger.setLevel(logging.DEBUG)
+    logger = logging.getLogger()
 
     #determine log levels
     output_log_level = logging.WARN #default
@@ -2140,6 +2139,9 @@ def setup_logging(options):
     # file level should be at least as verbose as output level
     file_log_level = min(file_log_level, output_log_level)
     options.file_log_level = file_log_level
+
+    # remove the default handler of root logger
+    logger.handlers = []
 
     # set up handlers
     handler = logging.StreamHandler(sys.stdout)
@@ -2199,6 +2201,7 @@ def main(args):
     options.branch = args[0]
     options.source = args[1]
 
+    logging.basicConfig(level=logging.DEBUG)
     options.config = get_config(options.cfile, options.copts)
 
     logger = setup_logging(options)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_loggers():
+    root_handlers = logging.getLogger().handlers[:]
+    altsrc_handlers = logging.getLogger("altsrc").handlers[:]
+    yield
+    logging.getLogger().handlers = root_handlers
+    logging.getLogger("altsrc").handlers = altsrc_handlers


### PR DESCRIPTION
Missing "logging.basicConfig" resulted in wrong logging behavior,
`No handlers could be found for logger "altsrc"`, instead of showing
the real valuable info, e.g. "ERROR:altsrc:Missing config file:".

```
# before fixing it
[root@dichen-pub-iib rpmbuild]# alt-src --push c7 funny-tom-1.1-4.src.rpm -c xxxx
No handlers could be found for logger "altsrc"

# after adding basicConfig
[root@dichen-pub-iib rpmbuild]# alt-src --push c7 funny-tom-1.1-4.src.rpm -c xxxx
ERROR:altsrc:Missing config file: xxxx
```