### PR TITLE
Upgrade codecov version to v2

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.5.0
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true
           verbose: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 koji
 rpm-py-installer
 requests
-PyYAML
+PyYAML==5.4.1
 simplejson
 six>=1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 koji
 rpm-py-installer
 requests
-PyYAML==5.4.1
+PyYAML
 simplejson
 six>=1.8.0


### PR DESCRIPTION
codecov version was updated to v2 in tox-test.yml as per https://issues.redhat.com/browse/RHELDST-8444

For py38 to work, pyYAML version was downgraded to 5.4.1. pyYAML version 6 was getting installed by default.