### PR TITLE
Fix compatibility with latest PyYAML

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -338,7 +338,7 @@ class BaseProcessor(object):
         module_data = self.mmd_parsed['data']
         fobj = open(self.source_file)
         try:
-            self.src_mmd_parsed = yaml.load(fobj)
+            self.src_mmd_parsed = yaml.load(fobj, Loader=yaml.BaseLoader)
         finally:
             fobj.close()
 
@@ -1356,7 +1356,7 @@ failed to apply.
                               "SOURCES",
                               os.path.basename(self.source_file)), "w")
         try:
-            yaml.dump(src_mmd_parsed_copy, fobj)
+            yaml.dump(src_mmd_parsed_copy, fobj, Dumper=yaml.SafeDumper)
         finally:
             fobj.close()
 

--- a/tests/test_debrand.py
+++ b/tests/test_debrand.py
@@ -189,7 +189,7 @@ def fake_mmd():
 @pytest.fixture
 def fake_src_mmd():
     with open(os.path.join(MODULES_PATH, "modulemd.src.txt")) as f:
-        return yaml.load(f)
+        return yaml.load(f, Loader=yaml.BaseLoader)
 
 
 @pytest.fixture()
@@ -475,9 +475,9 @@ def test_rule_mmd_no_change(stager_setup):
     stager.read_source_file()
     stager.debrand()
     with open(os.path.join(checkout_dir, "SOURCES", "modulemd.src.txt")) as f:
-        mmd1 = yaml.load(f)
+        mmd1 = yaml.load(f, Loader=yaml.BaseLoader)
 
     with open(os.path.join(MODULES_PATH, "modulemd.src.txt")) as f:
-        mmd2 = yaml.load(f)
+        mmd2 = yaml.load(f, Loader=yaml.BaseLoader)
 
     assert_that(mmd1, equal_to(mmd2))


### PR DESCRIPTION
yaml.load without Loader has been deprecated for a long time,
and the argument was finally made mandatory as of PyYAML 6.
Update all calls to always specify a Loader.
    
Note that we had already updated one yaml load to use BaseLoader
in 59282807 to fix a bug, but others were not changed at that time.
    
It is additionally required to explicitly set SafeDumper while
calling yaml.dump during debranding, otherwise introducing BaseLoader
would have the side-effect of introducing 'python/unicode' tags
everywhere as data is round-tripped. This is demonstrated by the
following experiments:
    
       >>> from yaml import dump, load, BaseLoader, SafeDumper
    
       # default: OK
       >>> dump(load(dump({'foo': 'bar'})))
       'foo: bar\n'
    
       # Adding BaseLoader: undesirable python-specific output
       >>> dump(load(dump({'foo': 'bar'}), Loader=BaseLoader))
       "!!python/unicode 'foo': !!python/unicode 'bar'\n"
    
       # Adding SafeDumper: OK
       # (note: per docs, BaseDumper is only intended for subclassing
       # and can't be used directly)
       >>> dump(load(dump({'foo': 'bar'}), Loader=BaseLoader), Dumper=SafeDumper)
       'foo: bar\n'