### PR TITLE
Update tox cov job to generate xml coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ whitelist_externals = sh
 
 [testenv:cov]
 basepython = python2.7
-commands = pytest --cov-report=html --cov=alt_src {posargs}
+commands = pytest --cov-report=html --cov-report=xml --cov=alt_src {posargs}
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
Codecov action to upload coverage report was upgraded to v2.
However, the reports were not uploaded correctly as v2 accepts
coverage reports in xml format only. Hence, updating the cov
job in tox to generate coverage reports in xml instead of html.