### PR TITLE
Encode the result of urlencode before calling urlopen 

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -1949,7 +1949,7 @@ class Pusher(BaseProcessor):
         }
 
         self.logger.info("Creating pagure repo:: %s", values)
-        data = urlencode(values)
+        data = urlencode(values).encode("utf-8")
         req = Request(
             self.options.config['pagure_repo_init_api'],
             data=data,


### PR DESCRIPTION
urlencode always returns a string, which is then used as the data
parameter in the urlopen function. However, on Python 3, data parameter
can only be bytes, so the result of urlencode must be encoded first.

Refers to CLOUDDST-13069