### PR TITLE
Resolve bandit findings for the repo

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -334,11 +334,11 @@ class BaseProcessor(object):
             self.read_srpm()
 
     def read_mmd(self):
-        self.mmd_parsed = yaml.load(self.mmd, Loader=yaml.BaseLoader)
+        self.mmd_parsed = yaml.load(self.mmd, Loader=yaml.BaseLoader) #nosec B506
         module_data = self.mmd_parsed['data']
         fobj = open(self.source_file)
         try:
-            self.src_mmd_parsed = yaml.load(fobj, Loader=yaml.BaseLoader)
+            self.src_mmd_parsed = yaml.load(fobj, Loader=yaml.BaseLoader) #nosec B506
         finally:
             fobj.close()
 
@@ -1033,7 +1033,7 @@ If you find this file in a distro specific branch, it means that no content has 
     def get_digest(self, path):
         """Calculate hex digest for file"""
 
-        csum = hashlib.sha1()
+        csum = hashlib.sha1() #nosec B324
         fobj = open(path, 'rb')
         chunk = 'IGNORE ME!'
         while chunk:
@@ -1956,7 +1956,7 @@ class Pusher(BaseProcessor):
             headers=headers,
         )
 
-        resp = urlopen(req)
+        resp = urlopen(req) #nosec B310
         resp = json.loads(resp.read())
         self.logger.info(resp)
 

--- a/tests/test_debrand.py
+++ b/tests/test_debrand.py
@@ -189,8 +189,7 @@ def fake_mmd():
 @pytest.fixture
 def fake_src_mmd():
     with open(os.path.join(MODULES_PATH, "modulemd.src.txt")) as f:
-        return yaml.load(f, Loader=yaml.BaseLoader)
-
+        return yaml.load(f, Loader=yaml.BaseLoader) #nosec B506
 
 @pytest.fixture()
 def test_dir(tmp_path):
@@ -475,9 +474,9 @@ def test_rule_mmd_no_change(stager_setup):
     stager.read_source_file()
     stager.debrand()
     with open(os.path.join(checkout_dir, "SOURCES", "modulemd.src.txt")) as f:
-        mmd1 = yaml.load(f, Loader=yaml.BaseLoader)
+        mmd1 = yaml.load(f, Loader=yaml.BaseLoader) #nosec B506
 
     with open(os.path.join(MODULES_PATH, "modulemd.src.txt")) as f:
-        mmd2 = yaml.load(f, Loader=yaml.BaseLoader)
+        mmd2 = yaml.load(f, Loader=yaml.BaseLoader) #nosec B506
 
     assert_that(mmd1, equal_to(mmd2))


### PR DESCRIPTION
As part of ESS Static Application Security Testing - SAST, we
ran Bandit SAST tool for this repo and had some medium and high
severity findings. This patch resolves those findings. Please
check the corresponding jira RHELDST-12101 for more details on
'#nosec' resolution.