### PR TITLE
Add bandit SAST scanning job to the CI [RHELDST-12101]

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -55,3 +55,35 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+  bandit-exitzero:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: |
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e bandit-exitzero
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install RPM
+        run: |
+          sudo apt-get install -y rpm
+          sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e bandit

--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -1033,7 +1033,7 @@ If you find this file in a distro specific branch, it means that no content has 
     def get_digest(self, path):
         """Calculate hex digest for file"""
 
-        csum = hashlib.sha1() #nosec B324
+        csum = hashlib.sha1() #nosec B324, B303
         fobj = open(path, 'rb')
         chunk = 'IGNORE ME!'
         while chunk:

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,11 @@ commands = pytest --cov-report=html --cov-report=xml --cov=alt_src {posargs}
 [pytest]
 testpaths = tests
 addopts = -v
+
+[testenv:bandit-exitzero]
+deps = bandit
+commands = bandit -r . -l --exclude './.tox' --exit-zero
+
+[testenv:bandit]
+deps = bandit
+commands = bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
To enable SAST scanning on this repository, Bandit has been added into the tox.ini and .github/workflows/tox-tests.yml files. Two tests are executed in the pipeline: bandit-exitzero and bandit.

The first scan lists all findings of low severity or higher and always passes due to the "exit-zero" option. This will allow tracking of low severity findings without stopping code from being merged in.

The second scan lists all findings of medium severity or higher and will fail the pipeline if any issues have been introduced.

Also, skips bandit issue B303:blacklist with a medium severity raised on using SHA1 hash for the file sent to lookaside.