### PR TITLE
Pin bandit version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,5 @@ rpm-py-installer
 # Locked for python 2.7 support
 pytest-cov==2.5.1
 pytest==3.9.1
+
+bandit==1.7.5

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ testpaths = tests
 addopts = -v
 
 [testenv:bandit-exitzero]
-deps = bandit
+deps = -rtest-requirements.txt
 commands = bandit -r . -l --exclude './.tox' --exit-zero
 
 [testenv:bandit]
-deps = bandit
+deps = -rtest-requirements.txt
 commands = bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to test-requirements.txt