### PR TITLE
pagure auth fails if token file contains trailing newline [RHELDST-2567]

### DIFF
--- a/alt_src/alt_src.py
+++ b/alt_src/alt_src.py
@@ -1929,7 +1929,7 @@ class Pusher(BaseProcessor):
         keyfile = None
         try:
             keyfile = open(self.options.config['pagure_api_key_file'], 'r')
-            key = keyfile.read()
+            key = keyfile.read().strip()
         finally:
             if keyfile:
                 keyfile.close()


### PR DESCRIPTION
1.add strip to remove the trailing newline